### PR TITLE
Added light/dark mode support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,0 @@
-# zen-cleaned-url-bar
-Cleans up zen's URL bar.

--- a/chrome.css
+++ b/chrome.css
@@ -1,41 +1,63 @@
-
-/* Blurs the background */
-#urlbar[breakout-extend="true"] #urlbar-background {
-    border: solid 3px color-mix(in hsl, hsl(0 0 50), transparent 90%) !important;
+@-moz-document url-prefix("chrome:") {
+  /* Blurs the background */
+  #urlbar[breakout-extend="true"] #urlbar-background {
     border-radius: 15px !important;
-    background-color: color-mix(in hsl, hsl(0 0 10), transparent 40%) !important;
-    backdrop-filter: blur(25px) !important;
-}
+    border: solid 3px color-mix(in hsl, hsl(0 0 50), transparent 90%) !important;
+  }
 
-#urlbar[breakout-extend="true"] .urlbar-input-container {
-    padding-top: 7px !important;
-    padding-bottom: 0px !important;
-}
+  @media (prefers-color-scheme: dark) {
+    #urlbar[breakout-extend="true"] #urlbar-background {
+      background-color: color-mix(
+        in hsl,
+        var(--mod-cleanedurlbar-customdarkcolor),
+        transparent var(--mod-cleanedurlbar-customtransparency)
+      ) !important;
+    }
+  }
 
-/* Unifies the border radius */
-.urlbarView-row {
-  border-radius: 11px !important;
-}
+  @media (prefers-color-scheme: light) {
+    #urlbar[breakout-extend="true"] #urlbar-background {
+      background-color: color-mix(
+        in hsl,
+        var(--mod-cleanedurlbar-customlightcolor),
+        transparent var(--mod-cleanedurlbar-customtransparency)
+      ) !important;
+    }
+  }
 
-/* Deletes the border */
-.urlbarView-body-inner {
-   border: none !important;
-}
+  /* Custom URL result selected color */
+  .urlbarView-row {
+    &[selected] {
+      background-color: var(--mod-cleanedurlbar-customselectcolor) !important;
+      color: var(--mod-cleanedurlbar-customselectfontcolor) !important;
+    }
+  }
 
-/* Styles the search options */
-.search-one-offs {
-  border-top: none !important;
-  border-radius: 10px !important;
-  padding: 4px !important;
-  margin: 0px 0px 7px 0px !important;
-  backdrop-filter: brightness(130%);
-}
+  /* Unifies the border radius */
+  .urlbarView-row {
+    border-radius: 11px !important;
+  }
 
-.searchbar-engine-one-off-item {
-  border-radius: 8px !important;
-  margin-right: 3px !important;
-}
+  /* Deletes the border */
+  .urlbarView-body-inner {
+    border: none !important;
+  }
 
-#urlbar-anon-search-settings {
-  margin-right: 0px !important;
+  /* Styles the search options */
+  .search-one-offs {
+    border-top: none !important;
+    border-radius: 10px !important;
+    padding: 4px !important;
+    margin: 0px 0px 7px 0px !important;
+    backdrop-filter: brightness(130%);
+  }
+
+  .searchbar-engine-one-off-item {
+    border-radius: 8px !important;
+    margin-right: 3px !important;
+  }
+
+  #urlbar-anon-search-settings {
+    margin-right: 0px !important;
+  }
 }

--- a/preferences.json
+++ b/preferences.json
@@ -1,0 +1,32 @@
+[
+    {
+        "property": "mod.cleanedurlbar.customdarkcolor",
+        "label": "Cleaned URL Bar Color (HSL only) [Dark Mode]",
+        "type": "string",
+        "defaultValue": "hsl(0 0 10)"
+    },
+    {
+        "property": "mod.cleanedurlbar.customlightcolor",
+        "label": "Cleaned URL Bar Color (HSL only) [Light Mode]",
+        "type": "string",
+        "defaultValue": "hsl(0 0 90)"
+    },
+    {
+        "property": "mod.cleanedurlbar.customtransparency",
+        "label": "Transparency (In percentage ex. 100%)",
+        "type": "string",
+        "defaultValue": "40%"
+    },
+    {
+        "property": "mod.cleanedurlbar.customselectcolor",
+        "label": "Selected URL color (rgb, hsl, hex)",
+        "type": "string",
+        "defaultValue": "rgba(80, 80, 250, 0.75)"
+    },
+    {
+        "property": "mod.cleanedurlbar.customselectfontcolor",
+        "label": "Selected URL font color (rgb, hsl, hex)",
+        "type": "string",
+        "defaultValue": "rgba(255,255,255,1)"
+    }
+]

--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,7 @@
+# Zen Cleaned URL Bar
+
+Cleans up zen's URL bar. Current customization:
+- The URL panel's color
+- The URL panel's transparency
+- The URL selected's color
+- The URL selected's font color


### PR DESCRIPTION
Hey, I just want to say that I love your mod! It makes Zen look so much cleaner and more polished—awesome work.

While using it, I noticed that the URL bar’s background color can sometimes look off depending on whether the system is in light or dark mode. To help with that, I added support for system theme detection using `prefers-color-scheme`, and included separate config values for light and dark mode backgrounds.

### Changes made:
- Replace `mod.cleanedurlbar.customcolor` with `mod.cleanedurlbar.customlightcolor` and `mod.cleanedurlbar.customdarkcolor` properties
- Updated the CSS to apply background colors conditionally based on system theme.
- Ensured default values maintain the mod’s existing visual style.

All the files were based on the latest version downloaded from the official zen mods page. I am also using Zen on Windows if that changes anything.

Let me know if you’d like me to tweak anything or make adjustments. Thanks again for the great mod!

![image](https://github.com/user-attachments/assets/4edba735-febf-48d3-9255-a8e108481a36)

