### PR TITLE
bugfix: change syntax to make transparency work

### DIFF
--- a/chrome.css
+++ b/chrome.css
@@ -13,8 +13,8 @@
     #urlbar[breakout-extend="true"] #urlbar-background {
       background-color: color-mix(
         in hsl,
-        var(--mod-cleanedurlbar-customdarkcolor),
-        transparent var(--mod-cleanedurlbar-customtransparency)
+        var(--mod-cleanedurlbar-customdarkcolor) var(--mod-cleanedurlbar-customtransparency),
+        transparent
       ) !important;
     }
   }
@@ -23,8 +23,8 @@
     #urlbar[breakout-extend="true"] #urlbar-background {
       background-color: color-mix(
         in hsl,
-        var(--mod-cleanedurlbar-customlightcolor),
-        transparent var(--mod-cleanedurlbar-customtransparency)
+        var(--mod-cleanedurlbar-customlightcolor) var(--mod-cleanedurlbar-customtransparency),
+        transparent
       ) !important;
     }
   }


### PR DESCRIPTION
# Context
For some reason, transparency wasn't being applied with the old syntax using the variable after the comma and `transparent`:
https://github.com/Dinno-DEV/zen-cleaned-url-bar/blob/b149a9cc46372dd6129828d9657eeec0f2ce1ead/chrome.css#L14-L18

# Resolution
By moving the `--mod-cleanedurlbar-customtransparency` variable to before the comma, transparency works. Maybe it's something related to how variables merge with CSS? I don't know, but here's the fix:
```css
background-color: color-mix(
  in hsl,
  var(--mod-cleanedurlbar-customdarkcolor) var(--mod-cleanedurlbar-customtransparency),
  transparent
) !important;
```
<sup>https://github.com/azeveco/zen-cleaned-url-bar/blob/c3a20ed4f08d4c5fe0c3ae4bffb0923d88354261/chrome.css#L14-L18</sup>

# Evidence
![zen_TcnQrPYxjK](https://github.com/user-attachments/assets/d855b47a-f9ec-405a-938b-35f48fb9c7f7)
