### PR TITLE
Restore backdrop-filter on Zen 1.19.9b+ / Firefox 150+

### DIFF
--- a/chrome.css
+++ b/chrome.css
@@ -1,6 +1,6 @@
 @-moz-document url-prefix("chrome:") {
 
-  /* Workaround: Firefox 150+ / Zen 1.19.9b+ broke backdrop-filter on child
+  /* Firefox 150+ / Zen 1.19.9b+ broke backdrop-filter on child
      elements by removing the stacking context from #browser. Re-establishing
      a no-op backdrop-filter on a parent element restores the behaviour. */
   #browser {
@@ -8,32 +8,28 @@
   }
 
   /* Blurs the background */
-  #urlbar[breakout-extend="true"] #urlbar-background {
+  #urlbar[breakout-extend="true"] .urlbar-background {
     border-radius: 15px !important;
     border: solid 3px color-mix(in hsl, hsl(0 0 50), transparent 90%) !important;
   }
 
-  #urlbar[breakout-extend="true"] #urlbar-background {
+  #urlbar[breakout-extend="true"] .urlbar-background {
     backdrop-filter: blur(25px) !important;
   }
-  
+
   @media (prefers-color-scheme: dark) {
-    #urlbar[breakout-extend="true"] #urlbar-background {
-      background-color: color-mix(
-        in hsl,
-        var(--mod-cleanedurlbar-customdarkcolor),
-        transparent var(--mod-cleanedurlbar-customtransparency)
-      ) !important;
+    #urlbar[breakout-extend="true"] .urlbar-background {
+      background-color: color-mix(in hsl,
+          var(--mod-cleanedurlbar-customdarkcolor),
+          transparent var(--mod-cleanedurlbar-customtransparency)) !important;
     }
   }
 
   @media (prefers-color-scheme: light) {
-    #urlbar[breakout-extend="true"] #urlbar-background {
-      background-color: color-mix(
-        in hsl,
-        var(--mod-cleanedurlbar-customlightcolor),
-        transparent var(--mod-cleanedurlbar-customtransparency)
-      ) !important;
+    #urlbar[breakout-extend="true"] .urlbar-background {
+      background-color: color-mix(in hsl,
+          var(--mod-cleanedurlbar-customlightcolor),
+          transparent var(--mod-cleanedurlbar-customtransparency)) !important;
     }
   }
 

--- a/chrome.css
+++ b/chrome.css
@@ -1,4 +1,12 @@
 @-moz-document url-prefix("chrome:") {
+
+  /* Workaround: Firefox 150+ / Zen 1.19.9b+ broke backdrop-filter on child
+     elements by removing the stacking context from #browser. Re-establishing
+     a no-op backdrop-filter on a parent element restores the behaviour. */
+  #browser {
+    backdrop-filter: blur(0) !important;
+  }
+
   /* Blurs the background */
   #urlbar[breakout-extend="true"] #urlbar-background {
     border-radius: 15px !important;

--- a/preferences.json
+++ b/preferences.json
@@ -21,7 +21,7 @@
         "property": "mod.cleanedurlbar.customselectcolor",
         "label": "Selected URL color (rgb, hsl, hex)",
         "type": "string",
-        "defaultValue": "rgba(80, 80, 250, 0.75)"
+        "defaultValue": "rgba(125, 125, 125, 0.65)"
     },
     {
         "property": "mod.cleanedurlbar.customselectfontcolor",

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,17 @@
-# Zen Cleaned URL Bar
+# Zen Cleaned URL Bar (Maintained Fork)
 
-Cleans up zen's URL bar. Current customization:
-- The URL panel's color
-- The URL panel's transparency
-- The URL selected's color
-- The URL selected's font color
+A maintained fork of [zen-cleaned-url-bar](https://github.com/dinnoyow/zen-cleaned-url-bar) by [@Dinno-DEV](https://github.com/dinnoyow), with bug fixes for recent Zen/Firefox versions.
+
+## What's different
+
+- **Fix transparent URL bar** — adds a no-op `backdrop-filter` on `#browser` to re-establish the stacking context removed upstream. Refs:
+  - https://github.com/zen-browser/desktop/issues/13389
+  - https://github.com/zen-browser/desktop/pull/13424
+- **Fix class selector** — `#urlbar-background` was converted to a class in Zen 1.16; updated selector to `.urlbar-background`
+
+## Customization
+
+- URL panel color
+- URL panel transparency
+- Selected result color
+- Selected result font color

--- a/readme.md
+++ b/readme.md
@@ -2,6 +2,8 @@
 
 A maintained fork of [zen-cleaned-url-bar](https://github.com/dinnoyow/zen-cleaned-url-bar) by [@Dinno-DEV](https://github.com/dinnoyow), with bug fixes for recent Zen/Firefox versions.
 
+<img width="1743" height="1184" alt="Image" src="https://github.com/user-attachments/assets/8b71dd02-7ef4-45d7-8238-50c0bc034385" />
+
 ## What's different
 
 - **Fix transparent URL bar** — adds a no-op `backdrop-filter` on `#browser` to re-establish the stacking context removed upstream. Refs:


### PR DESCRIPTION
Fix fully transparent URL bar by adding a no-op backdrop-filter on `#browser` to re-establish the stacking context removed upstream. Refs:
- https://github.com/zen-browser/desktop/issues/13389
- https://github.com/zen-browser/desktop/pull/13424