### PR TITLE
Restore backdrop-filter on Zen 1.19.9b+ / Firefox 150+

### DIFF
--- a/chrome.css
+++ b/chrome.css
@@ -1,4 +1,12 @@
 @-moz-document url-prefix("chrome:") {
+
+  /* Workaround: Firefox 150+ / Zen 1.19.9b+ broke backdrop-filter on child
+     elements by removing the stacking context from #browser. Re-establishing
+     a no-op backdrop-filter on a parent element restores the behaviour. */
+  #browser {
+    backdrop-filter: blur(0) !important;
+  }
+
   /* Blurs the background */
   #urlbar[breakout-extend="true"] #urlbar-background {
     border-radius: 15px !important;


### PR DESCRIPTION
Add no-op backdrop-filter on #browser to re-establish the stacking context removed upstream, fixing fully transparent URL bar. Refs:
- https://github.com/zen-browser/desktop/issues/13389
- https://github.com/zen-browser/desktop/pull/13424